### PR TITLE
Add support for multiple different calls to same cached func by hashing args

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ That means:
 - 🧰 **Mock-friendly cache files** that can be reused as test data, eliminating the need to hit real APIs or recompute fixtures  
 - 🔍 **Transparent storage** in a `.devstash_cache/` folder — easy to inspect, clear, or share  
 - 👥 **Team-ready**: share cached results across machines to save setup time  
-- 📓 **Jupyter-friendly**: mark heavy cells with `# @devstash` to skip them on reruns  
 
 ---
 
@@ -26,12 +25,14 @@ pip install devstash
 ```
 
 ```python
+import time
 import devstash
 
 devstash.activate()  # ✅ enable caching for this run
 
 def slow_function(x):
     print("Running slow_function...")
+    time.sleep(10)
     return x * 2
 
 val = slow_function(10)  # @devstash
@@ -51,7 +52,8 @@ print(val)
 - **Automatic restore**: cached values are re-injected into your program on the next run  
 - **Logging integration**: view caching activity with Python’s logging system  
 - **Zero dependencies** (just Python stdlib)  
-- **Optional TTL (time-to-live)** to expire cache after a given time (e.g. `30m`, `2h`, `1d`, `1w`)  
+- **Optional TTL (time-to-live)** to expire cache after a given time (e.g. `30m`, `2h`, `1d`, `1w`)
+- **Argument-sensitive caching**: separate cache files are created for different function arguments, so `foo(1, 2)` and `foo(2, 3)` won’t overwrite each other’s results.
 
 ---
 

--- a/devstash/__init__.py
+++ b/devstash/__init__.py
@@ -28,8 +28,14 @@ def activate():
     skip = os.environ.get("DEVSTASH_SKIP_REWRITE", "").lower() in ("1", "true", "yes")
     if main_file.exists() and not skip:
         os.environ["DEVSTASH_ACTIVE"] = "1"
+        warning_banner = """
+==================================================================
+ WARNING: devstash is active!
+ This tool is for DEVELOPMENT ONLY — do not use in production.
+==================================================================
+        """
+        print(warning_banner, file=sys.stderr)
         rewrite_and_run_main(main_file, devstash_cache_call)
-        logger.debug("AST rewritten, devstash active")
 
 
 __all__ = ["activate"]

--- a/devstash/_cache.py
+++ b/devstash/_cache.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import pickle
 import re
@@ -7,7 +8,6 @@ from pathlib import Path
 
 CACHE_DIR = Path("./.devstash_cache")
 _TTL_PATTERN = re.compile(r"(?P<value>\d+)(?P<unit>[smhdw])")
-
 
 logger = logging.getLogger("devstash")
 
@@ -32,15 +32,30 @@ def parse_ttl(ttl_str: str) -> timedelta:
         raise ValueError(f"Unsupported TTL unit: {unit}. Must be one of s, m, h, d, w.")
 
 
+def _hash_args_kwargs(args, kwargs) -> str:
+    """
+    Deterministically hash function args/kwargs into a short string.
+    Uses pickle for serialization, then SHA256.
+    """
+    try:
+        payload = pickle.dumps((args, kwargs))
+        return hashlib.sha256(payload).hexdigest()[:16]  # short digest
+    except Exception as e:
+        logger.warning(f"[devstash] Could not pickle args/kwargs for cache key: {e}")
+        return "nohash"
+
+
 def devstash_cache_call(func, *args, ttl: str = None, **kwargs):
     """
     Wraps a function call with caching.
-    Cache file is named: <module>__<qualname>.pkl
+    Cache file is named: <module>__<qualname>__<hash>.pkl
     TTL optional: e.g. ttl="1d", "30m", "2h"
     """
     mod = func.__module__ or "main"
     qual = getattr(func, "__qualname__", func.__name__)
-    filename = f"{mod}__{qual}.pkl"
+    arg_hash = _hash_args_kwargs(args, kwargs)
+
+    filename = f"{mod}__{qual}__{arg_hash}.pkl"
     path = CACHE_DIR / filename.replace("<", "_").replace(">", "_")
 
     if path.exists():
@@ -50,27 +65,27 @@ def devstash_cache_call(func, *args, ttl: str = None, **kwargs):
                 age = time.time() - path.stat().st_mtime
                 if age <= td.total_seconds():
                     with open(path, "rb") as f:
-                        logger.debug(f"Cache valid, loading from {path}")
+                        logger.debug(f"[devstash] Cache valid, loading from {path}")
                         return pickle.load(f)
                 else:
-                    logger.debug(f"Cache expired (age {age:.0f}s > {ttl}), refreshing...")
+                    logger.debug(f"[devstash] Cache expired (age {age:.0f}s > {ttl}), refreshing...")
             except Exception as e:
-                logger.warning(f"Failed to apply TTL ({ttl}): {e}")
+                logger.warning(f"[devstash] Failed to apply TTL ({ttl}): {e}")
         else:
             with open(path, "rb") as f:
-                logger.debug(f"Cache hit, loading from {path}")
+                logger.debug(f"[devstash] Cache hit, loading from {path}")
                 return pickle.load(f)
 
     # Cache miss or expired
-    logger.debug("No valid cache available, calling actual...")
+    logger.debug("[devstash] No valid cache available, calling actual...")
     result = func(*args, **kwargs)
 
     try:
         CACHE_DIR.mkdir(exist_ok=True)
         with open(path, "wb") as f:
-            logger.debug(f"Saving pickled object to {path}")
             pickle.dump(result, f)
+            logger.debug(f"[devstash] Saved result to {path}")
     except Exception:
-        logger.exception("Failed to devstash object.")
+        logger.exception("[devstash] Failed to save object.")
 
     return result

--- a/tests/test_devstash.py
+++ b/tests/test_devstash.py
@@ -4,6 +4,7 @@ import subprocess
 import time
 from pathlib import Path
 
+from devstash import devstash_cache_call
 from devstash._ast_rewrite import (
     DEVSTASH_INLINE_RE,
     DEVSTASH_STANDALONE_RE,
@@ -85,9 +86,10 @@ print(val)
 """
     run_script(tmp_path, script)
     files = list(map(str, CACHE_DIR.glob("*.pkl")))
-    expected_filename = ".devstash_cache/__main____f.pkl"
-    assert expected_filename in files, "Expected a cache file to be written"
-    with open(expected_filename, "rb") as f:
+    assert len(files) == 1
+    expected_filename = ".devstash_cache/__main____f"
+    assert expected_filename in files[0], "Expected a cache file to be written"
+    with open(files[0], "rb") as f:
         val = pickle.load(f)
     assert val == 42
 
@@ -170,3 +172,47 @@ def test_no_marker_does_not_wrap():
 
     result = ast.unparse(new_tree)
     assert result == src
+
+
+def dummy_func(x, y=1):
+    return x + y
+
+
+def test_devstash_cache_call_with_args():
+    # First call with (1, 2)
+    result1 = devstash_cache_call(dummy_func, 1, 2)
+    assert result1 == 3
+    files = list(CACHE_DIR.glob("*.pkl"))
+    assert len(files) == 1
+    cache_file = files[0]
+
+    # Second call with same args - should reuse cache
+    result2 = devstash_cache_call(dummy_func, 1, 2)
+    assert result2 == 3
+    assert cache_file.exists()
+
+    # Different args - new file
+    result3 = devstash_cache_call(dummy_func, 2, 3)
+    assert result3 == 5
+    files = list(CACHE_DIR.glob("*.pkl"))
+    assert len(files) == 2
+
+
+def test_devstash_cache_call_with_kwargs():
+    # Call with kwargs
+    result1 = devstash_cache_call(dummy_func, x=2, y=5)
+    assert result1 == 7
+    files = list(CACHE_DIR.glob("*.pkl"))
+    assert len(files) == 1
+    cache_file = files[0]
+
+    # Repeat same kwargs - should hit cache
+    result2 = devstash_cache_call(dummy_func, x=2, y=5)
+    assert result2 == 7
+    assert cache_file.exists()
+
+    # Different kwargs - new file
+    result3 = devstash_cache_call(dummy_func, x=3, y=5)
+    assert result3 == 8
+    files = list(CACHE_DIR.glob("*.pkl"))
+    assert len(files) == 2


### PR DESCRIPTION
- Add support for multiple cached calls to the same func, but with different call args. This is done by hashing the args and incorporating that into the cache filename
- Added a print to stderr with a warning banner not to use in production
- Removed mention of juypter notebook in readme as this is currently untested
